### PR TITLE
feat: set GitHub default token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,7 @@ inputs:
     description: >
       Token to authenticate with the ghcr.io registry and the GitHub API
     required: true
+    default: ${{ github.token }}
 
   owner:
     description: >


### PR DESCRIPTION
This adds default `github.token`, which is the same as `secrets.GITHUB_TOKEN` .