### PR TITLE
Update Node.js version from 20 to 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -143,5 +143,5 @@ inputs:
     required: false
 
 runs:
-  using: node20
+  using: node24
   main: dist/index.js


### PR DESCRIPTION
Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/